### PR TITLE
ログインしているユーザに紐付いているPJだけを表示する

### DIFF
--- a/app/Http/Controllers/FromCompanyProjectPostController.php
+++ b/app/Http/Controllers/FromCompanyProjectPostController.php
@@ -14,43 +14,33 @@ class FromCompanyProjectPostController extends Controller
     public function postProject(Request $request)
     {
         //プロジェクト変更をクリックした場合
-        if(!($request->project_change == "")){
-            $from_company_post_id = $request->from_company_id;
-            // $prefectures = Prefecture::all();
-            // $categories = Category::all();
+        if (!($request->project_change == "")) {
             $pagenate_counts = 1000;
-            $fromCompany = FromCompany::where('id', $from_company_post_id)->first();
-            $fromCompanies = FromCompany::all();
-    
-            // $toCompanies = ToCompany::orderBy('id','asc')->where('possible_send_flag','0')->where('from_company_id',$from_company_post_id)->paginate($pagenate_counts);
-            $toCompanies = ToCompany::orderBy('id','asc')->where('possible_send_flag','0')->where('from_company_id',$from_company_post_id)->paginate($pagenate_counts);
+            $from_company_post_id = $request->from_company_id;
 
-            $count = ToCompany::orderBy('send_date','asc')->get()->count() / $pagenate_counts;
-            $total_count = ToCompany::orderBy('send_date','asc')->get()->count();
+            // ユーザに紐付いているFromCompanyを全て取得
+            $user = \Auth::user();
+            $fromCompanies = FromCompany::where('user_id', $user->id)->orderBy('id','asc')->get();
+
+            // リクエストで指定されたFromCompanyを営業対象にする
+            $fromCompany = FromCompany::where('id', $from_company_post_id)->where('user_id', $user->id)->first();
+            $toCompanies = ToCompany::where('from_company_id', $from_company_post_id)->where('possible_send_flag','0')->orderBy('id','asc')->paginate($pagenate_counts);
     
             return view('change_project')
                     ->with('fromCompany', $fromCompany)
                     ->with('fromCompanies', $fromCompanies)
                     ->with('from_company_post_id', $from_company_post_id)
                     ->with('toCompanies', $toCompanies);
-                  
+        }
 
         //プロジェクト編集をクリックした場合
-            }else{
-                $from_company_post_id = $request->from_company_id;
-                $fromCompany = FromCompany::where('id', $from_company_post_id)->first();
-                $fromCompanies = FromCompany::all();
-                return view('/from_companies/edit_project')
-                      ->with('fromCompany', $fromCompany)
-                      ->with('fromCompanies', $fromCompanies);
+        else {
+            $from_company_post_id = $request->from_company_id;
+            $fromCompany = FromCompany::where('id', $from_company_post_id)->first();
+            $fromCompanies = FromCompany::all();
+            return view('/from_companies/edit_project')
+                    ->with('fromCompany', $fromCompany)
+                    ->with('fromCompanies', $fromCompanies);
         }    
-
-        
-
     }
-
-
-
-  
-
 }

--- a/database/migrations/2019_10_01_200804_add_column_to_from_companies_table2.php
+++ b/database/migrations/2019_10_01_200804_add_column_to_from_companies_table2.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class AddColumnToFromCompaniesTable extends Migration
+class AddColumnToFromCompaniesTable2 extends Migration
 {
     /**
      * Run the migrations.

--- a/database/migrations/2019_10_01_201333_drop_column_to_from_companies_table2.php
+++ b/database/migrations/2019_10_01_201333_drop_column_to_from_companies_table2.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class AddColumnToCompanies extends Migration
+class DropColumnToFromCompaniesTable2 extends Migration
 {
     /**
      * Run the migrations.
@@ -13,8 +13,8 @@ class AddColumnToCompanies extends Migration
      */
     public function up()
     {
-        Schema::table('to_companies', function (Blueprint $table) {
-            $table->string('list_charge');
+        Schema::table('from_companies', function (Blueprint $table) {
+            $table->dropColumn('project_name');
         });
     }
 
@@ -25,8 +25,8 @@ class AddColumnToCompanies extends Migration
      */
     public function down()
     {
-        Schema::table('to_companies', function (Blueprint $table) {
-            //
+        Schema::table('from_companies', function (Blueprint $table) {
+            $table->integer('project_name')->default(false);
         });
     }
 }

--- a/database/migrations/2019_10_01_201452_add_column_to_from_companies_table3.php
+++ b/database/migrations/2019_10_01_201452_add_column_to_from_companies_table3.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class AddColumnToCompanies extends Migration
+class AddColumnToFromCompaniesTable3 extends Migration
 {
     /**
      * Run the migrations.
@@ -13,8 +13,8 @@ class AddColumnToCompanies extends Migration
      */
     public function up()
     {
-        Schema::table('to_companies', function (Blueprint $table) {
-            //
+        Schema::table('from_companies', function (Blueprint $table) {
+            $table->string('project_name');
         });
     }
 
@@ -25,7 +25,7 @@ class AddColumnToCompanies extends Migration
      */
     public function down()
     {
-        Schema::table('to_companies', function (Blueprint $table) {
+        Schema::table('from_companies', function (Blueprint $table) {
             //
         });
     }

--- a/database/migrations/2020_03_06_235149_add_column_to_companies2.php
+++ b/database/migrations/2020_03_06_235149_add_column_to_companies2.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class AddColumnToFromCompaniesTable extends Migration
+class AddColumnToCompanies2 extends Migration
 {
     /**
      * Run the migrations.
@@ -13,8 +13,8 @@ class AddColumnToFromCompaniesTable extends Migration
      */
     public function up()
     {
-        Schema::table('from_companies', function (Blueprint $table) {
-            $table->string('project_name');
+        Schema::table('to_companies', function (Blueprint $table) {
+            //
         });
     }
 
@@ -25,7 +25,7 @@ class AddColumnToFromCompaniesTable extends Migration
      */
     public function down()
     {
-        Schema::table('from_companies', function (Blueprint $table) {
+        Schema::table('to_companies', function (Blueprint $table) {
             //
         });
     }

--- a/database/migrations/2020_03_06_235407_add_column_to_companies3.php
+++ b/database/migrations/2020_03_06_235407_add_column_to_companies3.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class DropColumnToFromCompaniesTable extends Migration
+class AddColumnToCompanies3 extends Migration
 {
     /**
      * Run the migrations.
@@ -13,8 +13,8 @@ class DropColumnToFromCompaniesTable extends Migration
      */
     public function up()
     {
-        Schema::table('from_companies', function (Blueprint $table) {
-            $table->dropColumn('project_name');
+        Schema::table('to_companies', function (Blueprint $table) {
+            $table->string('list_charge');
         });
     }
 
@@ -25,8 +25,8 @@ class DropColumnToFromCompaniesTable extends Migration
      */
     public function down()
     {
-        Schema::table('from_companies', function (Blueprint $table) {
-            $table->integer('project_name')->default(false);
+        Schema::table('to_companies', function (Blueprint $table) {
+            //
         });
     }
 }

--- a/database/migrations/2020_05_13_010849_add_user_id_to_from_companies_table.php
+++ b/database/migrations/2020_05_13_010849_add_user_id_to_from_companies_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUserIdToFromCompaniesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('from_companies', function (Blueprint $table) {
+            $sql = '
+ALTER TABLE `from_companies`
+ADD `user_id` BIGINT UNSIGNED NULL AFTER `project_name`,
+ADD INDEX `idx_from_companies_02` (`user_id`);';
+
+            DB::connection()->getPdo()->exec($sql);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('from_companies', function (Blueprint $table) {
+            $sql = '
+ALTER TABLE `from_companies`
+DROP `user_id`';
+
+            DB::connection()->getPdo()->exec($sql);
+        });
+    }
+}


### PR DESCRIPTION
ログインしているユーザに紐付いているPJだけを表示するようにしました。
from_companiesテーブルにuser_idカラムを追加しています。
運用時はfrom_companiesのuser_idカラムに紐付けたいユーザのIDを設定して下さい。
マイグレーションファイルも作成していますので、php artisan migrateでマイグレート可能です。

また、既存のマイグレーションが失敗する件（空のDBに対してphp artisan migrateをするとコケる）の修正も行っております。
この原因はマイグレーションファイルに同じクラス名が使われていた事でした。
具体的にはAddColumnToFromCompaniesTableクラス等が複数存在していました。
適宜末尾に数字を付加して対処しました。